### PR TITLE
Removed erroneous tag causing button bug

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -10,5 +10,3 @@
 
 [GitHub](https://github.com/bundlewatch/bundlewatch)
 [Get Started](#bundlewatch)
-
-![color](linear-gradient(to left bottom, #b3c8ff 0%,#fffcb3 100%))


### PR DESCRIPTION
Noticed that the main CTA buttons on _coverpage.md weren't rendering properly - noticed it was due to the unneeded tag below:

```
![color](linear-gradient(to left bottom, #b3c8ff 0%,#fffcb3 100%))
```